### PR TITLE
Fix for using the package with Spark 2.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparkavro
 Type: Package
 Title: Load Avro file into Apache Spark
-Version: 0.1.0
+Version: 0.2.0
 Author: Aki Ariga
 Maintainer: Aki Ariga <chezou@gmail.com>
 Description: Load Avro files into Apache Spark using 'sparklyr'. This

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -2,8 +2,10 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
     spark_avro_version = ""
     if (spark_version < "2.0.0") {
       spark_avro_version = "2.0.1"
-    } else {
+    } else if (spark_version < "2.2.0") {
       spark_avro_version = "3.2.0"
+    } else {
+      spark_avro_version = "4.0.0"
     }
 
     sparklyr::spark_dependency(


### PR DESCRIPTION
Currently trying to use this package with Spark 2.3 fails on the `spark_write_avro` command. This PR fixes this by changing the version of spark-avro that is used for Spark 2.2 and above to version 4.0.0. This is a fix for issue #9 