### PR TITLE
Updated dependencies to support Spark 2.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@
 language: R
 sudo: false
 cache: packages
+
+apt_packages:
+  - openjdk-8-jdk
+env:
+  - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,18 +1,25 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
     spark_avro_version = ""
+    spark_avro_lib = "com.databricks"
     if (spark_version < "2.0.0") {
       spark_avro_version = "2.0.1"
     } else if (spark_version < "2.2.0") {
       spark_avro_version = "3.2.0"
-    } else {
+    } else if (spark_version < "2.4.0") {
       spark_avro_version = "4.0.0"
+    } else {
+      spark_avro_lib = "org.apache.spark"
+      # Full semantic version is needed, so 2.4 -> 2.4.0
+      if (nchar(as.character(spark_version)) == 3) {
+        spark_avro_version = numeric_version(paste0(spark_version, ".0"))
+      } else spark_avro_version = spark_version
     }
 
     sparklyr::spark_dependency(
     jars = c(
     ),
     packages = c(
-      sprintf("com.databricks:spark-avro_%s:%s", scala_version, spark_avro_version)
+      sprintf("%s:spark-avro_%s:%s", spark_avro_lib, scala_version, spark_avro_version)
     )
   )
 }

--- a/tests/testthat/test_sparkavro.R
+++ b/tests/testthat/test_sparkavro.R
@@ -8,12 +8,12 @@ if(!exists("sc")){
 }
 
 test_that("read existing avro", {
-  df <- spark_read_avro(sc, "twitter", system.file("extdata", package="sparkavro"), "twitter.avro", memory = FALSE)
+  df <- spark_read_avro(sc, "twitter", system.file("extdata", "twitter.avro", package="sparkavro"), memory = FALSE)
   expect_equal(df %>% collect() %>% length(), 3)
 })
 
 test_that("write Spark DataFrame into avro", {
-  df <- spark_read_avro(sc, "twitter", system.file("extdata", package="sparkavro"), "twitter.avro", memory = FALSE)
+  df <- spark_read_avro(sc, "twitter", system.file("extdata", "twitter.avro", package="sparkavro"), memory = FALSE)
   df2 <- df %>% filter(username == "miguno")
   filename <- tempfile("test", fileext=".avro")
   spark_write_avro(df2, filename)


### PR DESCRIPTION
As of Spark 2.4 spark-avro has moved to the main Spark project changing the name and versioning of the package. I've updated the code to reflect this.

See here for details: https://spark.apache.org/docs/2.4.4/sql-data-sources-avro.html